### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
         license='Apache Software License (http://www.apache.org/licenses/LICENSE-2.0)',
         python_requires='>=3.6, <4',
         packages=['MDR'],
-        install_requires=["numpy", "pandas", "SimpleITK", "itk-elastix"],
+        install_requires=["numpy", "pandas", "SimpleITK", "itk-elastix", "pydicom", "Pillow", "pdoc3", "scipy"],
         include_package_data=True,
         keywords=['python', "medical imaging", "DICOM", "MRI", "renal", "kidney", "motion correction", "registration"],
         # Classifiers - the purpose is to create a wheel and upload it to PYPI


### PR DESCRIPTION
When I went to run the example test using MDR_test_main.py, I needed these dependencies which were missing when I setup my virtual machine using the pip install mdr-library command.